### PR TITLE
createText -> createTextNode

### DIFF
--- a/lib/js/tests/dom/nodes/document_test.js
+++ b/lib/js/tests/dom/nodes/document_test.js
@@ -75,7 +75,7 @@ document.createNodeIterator(el, Curry._1(DomTypesRe.WhatToShow[/* many */13], /*
 
 document.createRange();
 
-document.createText("Very reasonable!");
+document.createTextNode("Very reasonable!");
 
 document.createTreeWalker(el);
 

--- a/src/dom/nodes/documentRe.re
+++ b/src/dom/nodes/documentRe.re
@@ -46,7 +46,7 @@ module Impl (T: { type t; }) => {
   external createNodeIteratorWithWhatToShowFilter : Dom.node_like 'a => DomTypesRe.WhatToShow.t => Dom.nodeFilter => Dom.nodeIterator = "createNodeIterator" [@@bs.send.pipe: T.t];
   /* createProcessingInstruction */
   external createRange : Dom.range = "" [@@bs.send.pipe: T.t];
-  external createText : string => Dom.text = "" [@@bs.send.pipe: T.t];
+  external createTextNode : string => Dom.text = "" [@@bs.send.pipe: T.t];
   external createTreeWalker : Dom.element_like 'a => Dom.treeWalker = "" [@@bs.send.pipe: T.t];
   external createTreeWalkerWithWhatToShow : Dom.element_like 'a => DomTypesRe.WhatToShow.t => Dom.treeWalker = "createTreeWalker" [@@bs.send.pipe: T.t];
   external createTreeWalkerWithWhatToShowFilter : Dom.element_like 'a => DomTypesRe.WhatToShow.t => Dom.nodeFilter => Dom.treeWalker = "createTreeWalker" [@@bs.send.pipe: T.t];

--- a/tests/dom/nodes/document_test.re
+++ b/tests/dom/nodes/document_test.re
@@ -34,7 +34,7 @@ let _ = createNodeIterator el document;
 let _ = createNodeIteratorWithWhatToShow el DomRe.WhatToShow._All document;
 let _ = createNodeIteratorWithWhatToShowFilter el DomRe.WhatToShow.(many [_Element, _Attribute]) (NodeFilter.make (fun _ => 0)) document;
 let _ = createRange document;
-let _ = createText "Very reasonable!" document;
+let _ = createTextNode "Very reasonable!" document;
 let _ = createTreeWalker el document;
 let _ = createTreeWalkerWithWhatToShow el DomRe.WhatToShow._All document;
 let _ = createTreeWalkerWithWhatToShowFilter el DomRe.WhatToShow.(many [_Element, _Attribute]) (NodeFilter.make (fun _ => 0)) document;


### PR DESCRIPTION
I believe `createText` should be `createTextNode`

 https://developer.mozilla.org/en-US/docs/Web/API/Document/createTextNode