### PR TITLE
Move HtmlDocument.readyState to Document.readyState

### DIFF
--- a/lib/js/src/dom/html/HtmlDocumentRe.js
+++ b/lib/js/src/dom/html/HtmlDocumentRe.js
@@ -22,9 +22,6 @@ function Impl() {
     self.dir = DomTypesRe.encodeDir(value);
     return /* () */0;
   };
-  var readyState = function (self) {
-    return DomTypesRe.decodeReadyState(self.readyState);
-  };
   var execCommand = function (command, show, value, self) {
     return +self.execCommand(command, Js_boolean.to_js_boolean(show), Js_null.from_opt(value));
   };
@@ -33,7 +30,6 @@ function Impl() {
           /* setDesignMode */setDesignMode,
           /* dir */dir,
           /* setDir */setDir,
-          /* readyState */readyState,
           /* execCommand */execCommand
         ];
 }
@@ -62,10 +58,6 @@ function setDir(self, value) {
   return /* () */0;
 }
 
-function readyState(self) {
-  return DomTypesRe.decodeReadyState(self.readyState);
-}
-
 function execCommand(command, show, value, self) {
   return +self.execCommand(command, Js_boolean.to_js_boolean(show), Js_null.from_opt(value));
 }
@@ -78,18 +70,20 @@ var ofNode = include$1[1];
 
 var compatMode = include$1[2];
 
-var visibilityState = include$1[3];
+var readyState = include$1[3];
+
+var visibilityState = include$1[4];
 
 exports.Impl            = Impl;
 exports.nodeType        = nodeType;
 exports.asHtmlDocument  = asHtmlDocument;
 exports.ofNode          = ofNode;
 exports.compatMode      = compatMode;
+exports.readyState      = readyState;
 exports.visibilityState = visibilityState;
 exports.designMode      = designMode;
 exports.setDesignMode   = setDesignMode;
 exports.dir             = dir;
 exports.setDir          = setDir;
-exports.readyState      = readyState;
 exports.execCommand     = execCommand;
 /* include Not a pure module */

--- a/lib/js/src/dom/nodes/DocumentRe.js
+++ b/lib/js/src/dom/nodes/DocumentRe.js
@@ -29,6 +29,9 @@ function Impl() {
   var compatMode = function (self) {
     return DomTypesRe.decodeCompatMode(self.compatMode);
   };
+  var readyState = function (self) {
+    return DomTypesRe.decodeReadyState(self.readyState);
+  };
   var visibilityState = function (self) {
     return DomTypesRe.decodeVisibilityState(self.visibilityState);
   };
@@ -36,6 +39,7 @@ function Impl() {
           /* asHtmlDocument */asHtmlDocument$1,
           /* ofNode */ofNode,
           /* compatMode */compatMode,
+          /* readyState */readyState,
           /* visibilityState */visibilityState
         ];
 }
@@ -73,6 +77,10 @@ function compatMode(self) {
   return DomTypesRe.decodeCompatMode(self.compatMode);
 }
 
+function readyState(self) {
+  return DomTypesRe.decodeReadyState(self.readyState);
+}
+
 function visibilityState(self) {
   return DomTypesRe.decodeVisibilityState(self.visibilityState);
 }
@@ -84,5 +92,6 @@ exports.nodeType        = nodeType;
 exports.asHtmlDocument  = asHtmlDocument$1;
 exports.ofNode          = ofNode;
 exports.compatMode      = compatMode;
+exports.readyState      = readyState;
 exports.visibilityState = visibilityState;
 /* include Not a pure module */

--- a/lib/js/tests/dom/html/htmlDocument_test.js
+++ b/lib/js/tests/dom/html/htmlDocument_test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var Curry          = require("bs-platform/lib/js/curry.js");
 var DocumentRe     = require("../../../src/dom/nodes/DocumentRe.js");
 var TestHelpers    = require("../../testHelpers.js");
 var HtmlDocumentRe = require("../../../src/dom/html/HtmlDocumentRe.js");
@@ -50,7 +51,7 @@ htmlDocument.location = "http://reason.ml";
 
 htmlDocument.plugins;
 
-HtmlDocumentRe.readyState(htmlDocument);
+Curry._1(HtmlDocumentRe.readyState, htmlDocument);
 
 htmlDocument.referrer;
 

--- a/src/dom/html/HtmlDocumentRe.re
+++ b/src/dom/html/HtmlDocumentRe.re
@@ -29,9 +29,6 @@ module Impl = (T: {type t;}) => {
   [@bs.get] external location : t_htmlDocument => Dom.location = "";
   [@bs.set] external setLocation : (t_htmlDocument, string) => unit = "location";
   [@bs.get] external plugins : t_htmlDocument => Dom.htmlCollection = "";
-  [@bs.get] external readyState : t_htmlDocument => string /* enum */ = "";
-  let readyState: t_htmlDocument => DomTypesRe.readyState =
-    (self) => DomTypesRe.decodeReadyState(readyState(self));
   [@bs.get] external referrer : t_htmlDocument => string = "";
   [@bs.get] external scripts : t_htmlDocument => Dom.htmlCollection = "";
   [@bs.get] external title : t_htmlDocument => string = "";

--- a/src/dom/nodes/DocumentRe.re
+++ b/src/dom/nodes/DocumentRe.re
@@ -30,6 +30,9 @@ module Impl = (T: {type t;}) => {
   [@bs.get] [@bs.return nullable] external pointerLockElement : T.t => option(Dom.element) = ""; /* experimental */
 
   [@bs.get] external preferredStyleSheetSet : T.t => string = "";
+  [@bs.get] external readyState : T.t => string /* enum */ = "";
+  let readyState: T.t => DomTypesRe.readyState =
+    (self) => DomTypesRe.decodeReadyState(readyState(self));
   [@bs.get] [@bs.return nullable] external scrollingElement : T.t => option(Dom.element) = "";
   [@bs.get] external selectedStyleSheetSet : T.t => string = "";
   [@bs.set] external setSelectedStyleSheetSet : (T.t, string) => unit = "selectedStyleSheetSet";


### PR DESCRIPTION
Hi, according to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState), the readyState attribute belongs to the `Document` interface, rather than the `HtmlDocument` one, so just make it accessible from there.

However, I don't know how to run tests?