### PR TITLE
Support bsb-native target js builds

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -5,6 +5,7 @@
 {
   "name": "bs-webapi",
   "bsc-flags": ["-bs-no-version-header", "-bs-super-errors"],
+  "allowed-build-kinds": "js",
   "sources": [
     {
       "dir": "src",


### PR DESCRIPTION
This will allow the lib to only compile when bsb is using js as the backend.
I had a problem when using this lib in a bsb-native project, props to @bsansouci for giving me this solution.