### PR TITLE
Expose NamedNodeMap in the DOM API

### DIFF
--- a/src/dom/DomRe.re
+++ b/src/dom/DomRe.re
@@ -34,6 +34,7 @@ module Location = LocationRe;
 module MouseEvent = MouseEventRe;
 module MutationObserver = MutationObserverRe;
 module MutationRecord = MutationRecordRe;
+module NamedNodeMap = NamedNodeMapRe;
 module Node = NodeRe;
 module NodeFilter = NodeFilterRe;
 module NodeList = NodeListRe;


### PR DESCRIPTION
This one seems to be missing. 