### PR TITLE
Add onerror to HtmlImageElementRe

### DIFF
--- a/src/dom/html/HtmlImageElementRe.re
+++ b/src/dom/html/HtmlImageElementRe.re
@@ -5,5 +5,6 @@ type t;
 [@bs.set] external src : (t, string) => unit = "";
 [@bs.get] external getSrc : t => string = "src";
 [@bs.set] external onload : (t, unit => unit) => unit = "";
+[@bs.set] external onerror : (t, unit => unit) => unit = "";
 [@bs.get] external naturalHeight : t => string = "";
 [@bs.get] external naturalWidth : t => string = "";


### PR DESCRIPTION
Allows writing code like this when loading an image:

```reason 
  let imageEl = HtmlImageElementRe.make();

  let myPromise =
    Js.Promise.make((~resolve, ~reject) => {
      HtmlImageElementRe.onload(imageEl, () => resolve(. imageEl));
      HtmlImageElementRe.onerror(imageEl, () =>
        reject(. Invalid_argument("could not load image"))
      );
    });

  HtmlImageElementRe.src(imageEl, "./tiles16.png");

```