### PR TITLE
Fix EventTarget dispatching of custom events

### DIFF
--- a/lib/js/tests/dom/events/eventTarget_test.js
+++ b/lib/js/tests/dom/events/eventTarget_test.js
@@ -31,7 +31,16 @@ target.removeEventListener("click", handleClick, true);
 
 target.dispatchEvent($$event);
 
+var customEvent = new CustomEvent("custom-event", {
+      detail: {
+        test: "test"
+      }
+    });
+
+target.dispatchEvent(customEvent);
+
 exports.target = target;
 exports.$$event = $$event;
 exports.handleClick = handleClick;
+exports.customEvent = customEvent;
 /* target Not a pure module */

--- a/src/dom/events/EventTargetRe.re
+++ b/src/dom/events/EventTargetRe.re
@@ -7,7 +7,7 @@ module Impl = (T: {type t;}) => {
   [@bs.send.pipe : T.t] external removeEventListener : (string, Dom.event => unit) => unit = "";
   [@bs.send.pipe : T.t] external removeEventListenerWithOptions : (string, Dom.event => unit, {. "capture": bool, "passive": bool}) => unit = "removeEventListener"; /* not widely supported */
   [@bs.send.pipe : T.t] external removeEventListenerUseCapture : (string, Dom.event => unit, [@bs.as {json|true|json}] _) => unit = "removeEventListener";
-  [@bs.send.pipe : T.t] external dispatchEvent : Dom.event => bool = "";
+  [@bs.send.pipe : T.t] external dispatchEvent : Dom.event_like('a) => bool = "";
 
   /**
    *  non-standard event-specific functions

--- a/tests/dom/events/eventTarget_test.re
+++ b/tests/dom/events/eventTarget_test.re
@@ -14,3 +14,7 @@ removeEventListener("click", handleClick, target);
 removeEventListenerWithOptions("click", handleClick, {"passive": true, "capture": false}, target);
 removeEventListenerUseCapture("click", handleClick, target);
 let _ = dispatchEvent(event, target);
+
+/* https://github.com/reasonml-community/bs-webapi-incubator/issues/103 */
+let customEvent = CustomEvent.makeWithOptions("custom-event", {"detail": {"test": "test"}});
+dispatchEvent(customEvent, target);


### PR DESCRIPTION
Make `EventTarget.dispatchEvent` so it takes any `Dom.event_like`.

Fixes #103.