### PR TITLE
Fix: StorageEvent oldValue and newValue can be null

### DIFF
--- a/src/dom/events/StorageEventRe.re
+++ b/src/dom/events/StorageEventRe.re
@@ -6,7 +6,7 @@ include EventRe.Impl({ type nonrec t = t; });
 [@bs.new] external makeWithOptions : (string, Js.t({..})) => t = "StorageEvent";
 
 [@bs.get] external key : t => string = "";
-[@bs.get] external newValue : t => string = "";
-[@bs.get] external oldValue : t => string = "";
+[@bs.get] external newValue : t => Js.Nullable.t(string) = "";
+[@bs.get] external oldValue : t => Js.Nullable.t(string) = "";
 [@bs.get] external storageArea : t => Dom.Storage.t = "";
 [@bs.get] external url : t => string = "";


### PR DESCRIPTION
Simple test case is:

```js
localStorage.setItem("foo", "bar"); // oldValue: null , newValue: "bar"
localStorage.removeItem("foo"); // oldValue: "bar", newValue: null
```