### PR TITLE
Add makeWithJson and makeWithObject to URLSearchParamsRe

### DIFF
--- a/src/file/URLSearchParamsRe.re
+++ b/src/file/URLSearchParamsRe.re
@@ -1,8 +1,8 @@
 type t;
 
 [@bs.new] external make: string => t = "URLSearchParams";
-[@bs.new] external makeWithJson: Js.Json.t => t = "URLSearchParams";
-[@bs.new] external makeWithObject: Js.t({..}) => t = "URLSearchParams";
+[@bs.new] external makeWithDict: Js.Dict.t(string) => t = "URLSearchParams";
+[@bs.new] external makeWithArray: array((string, string)) => t = "URLSearchParams";
 [@bs.send.pipe : t] external append: (string, string) => unit = "";
 [@bs.send.pipe : t] external delete: string => unit = "";
 [@bs.send.pipe : t] external entries: Js.Array.array_like(string) = "";

--- a/src/file/URLSearchParamsRe.re
+++ b/src/file/URLSearchParamsRe.re
@@ -1,6 +1,8 @@
 type t;
 
 [@bs.new] external make: string => t = "URLSearchParams";
+[@bs.new] external makeWithJson: Js.Json.t => t = "URLSearchParams";
+[@bs.new] external makeWithObject: Js.t({..}) => t = "URLSearchParams";
 [@bs.send.pipe : t] external append: (string, string) => unit = "";
 [@bs.send.pipe : t] external delete: string => unit = "";
 [@bs.send.pipe : t] external entries: Js.Array.array_like(string) = "";


### PR DESCRIPTION
This corresponds with the use case where you want to create a query string using an object:
```reason
URLSearchParamsRe.makeWithObject({"foo": "hello", "bar": "world"})
  ->URLSearchParamsRe.toString;
```