### PR TITLE
Remove 'pointless' window reference (which shadows the real reference)

### DIFF
--- a/src/Webapi/Webapi__Dom/Webapi__Dom__Window.re
+++ b/src/Webapi/Webapi__Dom/Webapi__Dom__Window.re
@@ -63,8 +63,6 @@ module Impl = (T: {type t;}) => {
   [@bs.get] external statusbar : t_window => statusbar = "";
   [@bs.get] external toolbar : t_window => toolbar = "";
   [@bs.get] external top : t_window => Dom.window = "";
-  [@bs.get] external window : t_window => t_window = ""; /* This is pointless I think, it's just here because window is the implicit global scope, and it's needed to be able to get a reference to it */
-
   [@bs.send.pipe : t_window] external alert : string => unit = "";
   [@bs.send.pipe : t_window] external blur : unit = "";
   [@bs.send.pipe : t_window] external cancelIdleCallback : idleCallbackId => unit = ""; /* experimental, Cooperative Scheduling of Background Tasks */

--- a/tests/Webapi/Webapi__Dom/Webapi__Dom__Window__test.re
+++ b/tests/Webapi/Webapi__Dom/Webapi__Dom__Window__test.re
@@ -43,7 +43,6 @@ let _ = Window.setStatus(window, "new status");
 let _ = Window.statusbar(window);
 let _ = Window.toolbar(window);
 let _ = Window.top(window);
-let _ = Window.window(window);
 
 Window.alert("hello!", window);
 Window.blur(window);


### PR DESCRIPTION
For ergonomics, it's nice to be able to do:
```ocaml
let open Webapi.Dom in
Window.innerWidth window
```
But this is only possible if `window` isn't defined as a property on `Window.t`. Of course, it _is_ such a property, but I don't think there's any valid use-case for accessing it.