### PR TITLE
Enforce private modules

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -8,7 +8,8 @@
   "sources": [
     {
       "dir": "src",
-      "subdirs": true
+      "subdirs": true,
+      "public": ["Webapi"]
     },
     {
       "dir": "tests",


### PR DESCRIPTION
Using BuckleScript's feature to only expose public modules.