### PR TITLE
Add Dom.Element height and width setters

### DIFF
--- a/src/Webapi/Webapi__Dom/Webapi__Dom__Element.re
+++ b/src/Webapi/Webapi__Dom/Webapi__Dom__Element.re
@@ -28,6 +28,8 @@ module Impl = (T: {type t;}) => {
   [@bs.get] external clientWidth : T.t => int = ""; /* experimental */
   [@bs.get] external id : T.t => string = "";
   [@bs.set] external setId : (T.t, string) => unit = "id";
+  [@bs.set] external setHeight : (T.t, int) => unit = "height";
+  [@bs.set] external setWidth : (T.t, int) => unit = "width";
   [@bs.get] external innerHTML : T.t => string = "";
   [@bs.set] external setInnerHTML : (T.t, string) => unit = "innerHTML";
   [@bs.get] external localName : T.t => string = "";


### PR DESCRIPTION
I spent a while trying to find these, and it doesn't seem like they're in the API?

New function bindings for Dom.Element: setHeight and setWidth, each taking an element and an integer, returning unit.