### PR TITLE
Add name method to Webapi.File module

### DIFF
--- a/src/Webapi/Webapi__File.re
+++ b/src/Webapi/Webapi__File.re
@@ -1,4 +1,7 @@
 type t;
 
 [@bs.get] external _type : t => string = "type";
+
+[@bs.get] external name : t => string = "name";
+
 [@bs.get] external preview : t => string = "";


### PR DESCRIPTION
This PR is to add `name` method so that the caller could retrieve file name with `Webapi.File.name(file)`