### PR TITLE
Add forEach to module URLSearchParams.

### DIFF
--- a/lib/js/tests/Webapi/Webapi__Url__test.js
+++ b/lib/js/tests/Webapi/Webapi__Url__test.js
@@ -3,9 +3,8 @@
 
 var params = new URLSearchParams("key1=value1&key2=value2");
 
-params.forEach((function (value, key) {
-        console.log(value);
-        console.log(key);
+params.forEach((function (prim, prim$1) {
+        console.log(prim, prim$1);
         return /* () */0;
       }));
 

--- a/lib/js/tests/Webapi/Webapi__Url__test.js
+++ b/lib/js/tests/Webapi/Webapi__Url__test.js
@@ -1,0 +1,13 @@
+'use strict';
+
+
+var params = new URLSearchParams("key1=value1&key2=value2");
+
+params.forEach((function (value, key) {
+        console.log(value);
+        console.log(key);
+        return /* () */0;
+      }));
+
+exports.params = params;
+/* params Not a pure module */

--- a/src/Webapi/Webapi__Url.re
+++ b/src/Webapi/Webapi__Url.re
@@ -7,6 +7,7 @@ module URLSearchParams = {
   [@bs.send.pipe : t] external append: (string, string) => unit = "";
   [@bs.send.pipe : t] external delete: string => unit = "";
   [@bs.send.pipe : t] external entries: Js.Array.array_like(string) = "";
+  [@bs.send.pipe : t] external forEach: ([@bs.uncurry] (string, string) => unit) => unit = "";
   [@bs.return nullable][@bs.send.pipe : t] external get: string => option(string) = "";
   [@bs.send.pipe : t] external getAll: string => array(string) = "";
   [@bs.send.pipe : t] external has: string => bool = "";

--- a/tests/Webapi/Webapi__Url__test.re
+++ b/tests/Webapi/Webapi__Url__test.re
@@ -1,0 +1,10 @@
+open Webapi.Url;
+
+let params = URLSearchParams.make("key1=value1&key2=value2");
+URLSearchParams.forEach(
+   (value, key) => {
+      print_endline(value);
+      print_endline(key);
+   },
+   params
+);

--- a/tests/Webapi/Webapi__Url__test.re
+++ b/tests/Webapi/Webapi__Url__test.re
@@ -1,10 +1,4 @@
 open Webapi.Url;
 
 let params = URLSearchParams.make("key1=value1&key2=value2");
-URLSearchParams.forEach(
-   (value, key) => {
-      print_endline(value);
-      print_endline(key);
-   },
-   params
-);
+URLSearchParams.forEach(Js.log2, params);


### PR DESCRIPTION
This PR adds the `forEach` method to the `URLSearchParams` module, as specified here: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/forEach. Users can now iterate over url search params as key-value pairs like so:

```reason
let params = URLSearchParams.make("key1=value1&key2=value2");
URLSearchParams.forEach(
   (value, key) => {
      print_endline(value);
      print_endline(key);
   },
   params
);

/*
value1
key1
value2
key2
*/
```

`refmt` also appears to have reformatted some of the lines in this module, but the addition of `forEach` is the only meaningful change here.