### PR TITLE
Selection.setBaseAndExtent

### DIFF
--- a/lib/js/tests/Webapi/Webapi__Dom/Webapi__Dom__Selection__test.js
+++ b/lib/js/tests/Webapi/Webapi__Dom/Webapi__Dom__Selection__test.js
@@ -41,6 +41,8 @@ sel.removeAllRanges();
 
 sel.deleteFromDocument();
 
+sel.setBaseAndExtent(node, 0, node, 0);
+
 sel.toString();
 
 sel.containsNode(node, false);

--- a/src/Webapi/Webapi__Dom/Webapi__Dom__Selection.re
+++ b/src/Webapi/Webapi__Dom/Webapi__Dom__Selection.re
@@ -13,6 +13,7 @@ type t = Dom.selection;
 [@bs.send.pipe : t] external collapseToStart : unit = "";
 [@bs.send.pipe : t] external collapseToEnd : unit = "";
 [@bs.send.pipe : t] external selectAllChildren : Dom.node_like(_) => unit = "";
+[@bs.send.pipe : t] external setBaseAndExtent : (Dom.node_like(_), int,  Dom.node_like(_), int) => unit = "";
 [@bs.send.pipe : t] external addRange : Dom.range => unit = "";
 [@bs.send.pipe : t] external removeRange : Dom.range => unit = "";
 [@bs.send.pipe : t] external removeAllRanges : unit = "";

--- a/tests/Webapi/Webapi__Dom/Webapi__Dom__Selection__test.re
+++ b/tests/Webapi/Webapi__Dom/Webapi__Dom__Selection__test.re
@@ -26,6 +26,7 @@ addRange(range, sel);
 removeRange(range, sel);
 removeAllRanges(sel);
 deleteFromDocument(sel);
+setBaseAndExtent(node, 0, node, 0, sel);
 let _ = toString(sel);
 let _ = containsNode(node, sel);
 let _ = containsNodePartly(node, sel);


### PR DESCRIPTION
This PR just adds the setBaseAndExtent function to the Selection module. It's implemented by all browsers except IE 11 and it's in this standard document:

https://w3c.github.io/selection-api/#dom-selection-setbaseandextent