### PR TITLE
doc(dom): fix example

### DIFF
--- a/examples/dom_example.re
+++ b/examples/dom_example.re
@@ -46,13 +46,13 @@ let el =
 
 /*
 document |> Document.asHtmlDocument
-         |> and_then HtmlDocument.body
+         |> andThen(HtmlDocument.body)
          |> map(Element.appendChild(el));
 */
 
 /* Before subtyping:
 document |> Document.asHtmlDocument
-         |> and_then(HtmlDocument.body)
+         |> andThen(HtmlDocument.body)
          |> map(Element.appendChild (el |> HtmlElement.asNode));
 */
 


### PR DESCRIPTION
Since https://github.com/reasonml-community/bs-webapi-incubator/commit/7a8f0d213a8ed37bb77aef3ed7dc49c1ad0b2065#diff-57a44c44f32b358d6bc2e1bb952dffc2, commented example are innacurate.