### PR TITLE
removed global conflict of None among other things

### DIFF
--- a/lib/js/src/Webapi/Webapi__Dom.js
+++ b/lib/js/src/Webapi/Webapi__Dom.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var Webapi__Dom__Types = require("./Webapi__Dom/Webapi__Dom__Types.js");
 
 var $$AnimationEvent = 0;
 
@@ -132,45 +131,7 @@ var $$WheelEvent = 0;
 
 var $$Window = 0;
 
-var encodeCompareHow = Webapi__Dom__Types.encodeCompareHow;
-
-var decodeCompareResult = Webapi__Dom__Types.decodeCompareResult;
-
-var decodeCompatMode = Webapi__Dom__Types.decodeCompatMode;
-
-var encodeContentEditable = Webapi__Dom__Types.encodeContentEditable;
-
-var decodeContentEditable = Webapi__Dom__Types.decodeContentEditable;
-
-var decodeDeltaMode = Webapi__Dom__Types.decodeDeltaMode;
-
-var encodeDesignMode = Webapi__Dom__Types.encodeDesignMode;
-
-var decodeDesignMode = Webapi__Dom__Types.decodeDesignMode;
-
-var encodeDir = Webapi__Dom__Types.encodeDir;
-
-var decodeDir = Webapi__Dom__Types.decodeDir;
-
-var decodeEventPhase = Webapi__Dom__Types.decodeEventPhase;
-
-var encodeFilterAction = Webapi__Dom__Types.encodeFilterAction;
-
-var encodeInsertPosition = Webapi__Dom__Types.encodeInsertPosition;
-
-var encodeModifierKey = Webapi__Dom__Types.encodeModifierKey;
-
-var decodeNodeType = Webapi__Dom__Types.decodeNodeType;
-
-var decodePointerType = Webapi__Dom__Types.decodePointerType;
-
-var decodeReadyState = Webapi__Dom__Types.decodeReadyState;
-
-var decodeShadowRootMode = Webapi__Dom__Types.decodeShadowRootMode;
-
-var decodeVisibilityState = Webapi__Dom__Types.decodeVisibilityState;
-
-var WhatToShow = Webapi__Dom__Types.WhatToShow;
+var Types = 0;
 
 exports.$$AnimationEvent = $$AnimationEvent;
 exports.$$Attr = $$Attr;
@@ -237,24 +198,5 @@ exports.$$ValidityState = $$ValidityState;
 exports.WebGlContextEvent = WebGlContextEvent;
 exports.$$WheelEvent = $$WheelEvent;
 exports.$$Window = $$Window;
-exports.encodeCompareHow = encodeCompareHow;
-exports.decodeCompareResult = decodeCompareResult;
-exports.decodeCompatMode = decodeCompatMode;
-exports.encodeContentEditable = encodeContentEditable;
-exports.decodeContentEditable = decodeContentEditable;
-exports.decodeDeltaMode = decodeDeltaMode;
-exports.encodeDesignMode = encodeDesignMode;
-exports.decodeDesignMode = decodeDesignMode;
-exports.encodeDir = encodeDir;
-exports.decodeDir = decodeDir;
-exports.decodeEventPhase = decodeEventPhase;
-exports.encodeFilterAction = encodeFilterAction;
-exports.encodeInsertPosition = encodeInsertPosition;
-exports.encodeModifierKey = encodeModifierKey;
-exports.decodeNodeType = decodeNodeType;
-exports.decodePointerType = decodePointerType;
-exports.decodeReadyState = decodeReadyState;
-exports.decodeShadowRootMode = decodeShadowRootMode;
-exports.decodeVisibilityState = decodeVisibilityState;
-exports.WhatToShow = WhatToShow;
+exports.Types = Types;
 /* No side effect */

--- a/src/Webapi/Webapi__Dom.re
+++ b/src/Webapi/Webapi__Dom.re
@@ -63,8 +63,7 @@ module ValidityState = Webapi__Dom__ValidityState;
 module WebGlContextEvent = Webapi__Dom__WebGlContextEvent;
 module WheelEvent = Webapi__Dom__WheelEvent;
 module Window = Webapi__Dom__Window;
-
-include Webapi__Dom__Types;
+module Types = Webapi__Dom__Types;
 
 [@bs.val] external window : Dom.window = "window";
 [@bs.val] external document : Dom.document = "document";

--- a/tests/Webapi/Webapi__Dom/Webapi__Dom__Document__test.re
+++ b/tests/Webapi/Webapi__Dom/Webapi__Dom__Document__test.re
@@ -31,13 +31,13 @@ let _ = createElementNS("http://...", "foo", document);
 let _ = createElementNSWithOptions("http://...", "div", [%bs.raw "{}"], document); /* I've no idea what this options object is supposed to be, even the spec doesn't seem to bother explaining it */
 let _ = createEvent("MyCustomEvent", document);
 let _ = createNodeIterator(el, document);
-let _ = createNodeIteratorWithWhatToShow(el, WhatToShow._All, document);
-let _ = createNodeIteratorWithWhatToShowFilter(el, WhatToShow.(many([_Element, _Attribute])), NodeFilter.make((_) => 0), document);
+let _ = createNodeIteratorWithWhatToShow(el, Types.WhatToShow._All, document);
+let _ = createNodeIteratorWithWhatToShowFilter(el, Types.WhatToShow.(many([_Element, _Attribute])), NodeFilter.make((_) => 0), document);
 let _ = createRange(document);
 let _ = createTextNode("Very reasonable!", document);
 let _ = createTreeWalker(el, document);
-let _ = createTreeWalkerWithWhatToShow(el, WhatToShow._All, document);
-let _ = createTreeWalkerWithWhatToShowFilter(el, WhatToShow.(many([_Element, _Attribute])), NodeFilter.make((_) => 0), document);
+let _ = createTreeWalkerWithWhatToShow(el, Types.WhatToShow._All, document);
+let _ = createTreeWalkerWithWhatToShowFilter(el, Types.WhatToShow.(many([_Element, _Attribute])), NodeFilter.make((_) => 0), document);
 let _ = elementFromPoint(0, 0, document);
 let _ = elementsFromPoint(0, 0, document);
 let _ = enableStyleSheetsForSet("my-stylesheet-set", document);


### PR DESCRIPTION
When using `open Webapi.Dom` you get a conflict with the Option value constructor `None` and the Webapi `eventPhase None`. I think all othe Webapi__Dom__Types should be in either separate modules or in it's own module to avoid this open conflict. This PR is a breaking change that wraps the Types in it's own module, I think it would make the Webapi easier to use.