### PR TITLE
added ofNode to Text

### DIFF
--- a/src/Webapi/Webapi__Dom/Webapi__Dom__Text.re
+++ b/src/Webapi/Webapi__Dom/Webapi__Dom__Text.re
@@ -1,4 +1,9 @@
+let ofNode = (node: Dom.node) : option('a) =>
+  Webapi__Dom__Node.nodeType(node) == Text ? Some(Obj.magic(node)) : None;
+
 module Impl = (T: {type t;}) => {
+  let ofNode: Dom.node => option(T.t) = ofNode;
+
   [@bs.send.pipe : T.t] external splitText : (~offset: int, unit) => Dom.text = "";
   [@bs.get] external wholeText : T.t => string = "";
 };

--- a/tests/Webapi/Webapi__Dom/Webapi__Dom__Text__test.re
+++ b/tests/Webapi/Webapi__Dom/Webapi__Dom__Text__test.re
@@ -1,0 +1,7 @@
+open Webapi.Dom;
+
+let node =
+  document |> Document.createTextNode("text")
+           |> Text.asNode;
+
+let text = Text.ofNode(node);


### PR DESCRIPTION
Added this function since we are converting nodes to text a lot and had it internally in the project. Since  Element and document has a ofNode it makes sense that the Text node has one as well.