### PR TITLE
Downcast DOM types by using `instanceof` to check types

### DIFF
--- a/lib/js/tests/Webapi/Webapi__Dom/Webapi__Dom__DomStringMap__test.js
+++ b/lib/js/tests/Webapi/Webapi__Dom/Webapi__Dom__DomStringMap__test.js
@@ -1,15 +1,23 @@
 'use strict';
 
 var Curry = require("bs-platform/lib/js/curry.js");
+var Belt_Option = require("bs-platform/lib/js/belt_Option.js");
+var Caml_option = require("bs-platform/lib/js/caml_option.js");
+var Webapi__Dom__Element = require("../../../src/Webapi/Webapi__Dom/Webapi__Dom__Element.js");
 var Webapi__Dom__DomStringMap = require("../../../src/Webapi/Webapi__Dom/Webapi__Dom__DomStringMap.js");
 
-var dataset = document.createElement("div").dataset;
+var __x = Curry._1(Webapi__Dom__Element.asHtmlElement, document.createElement("div"));
 
-Webapi__Dom__DomStringMap.set("fooKey", "barValue", dataset);
+var dataset = Belt_Option.map(__x, (function (prim) {
+        return prim.dataset;
+      }));
 
-Webapi__Dom__DomStringMap.get("fooKey", dataset);
-
-Curry._2(Webapi__Dom__DomStringMap.unsafeDeleteKey, "fooKey", dataset);
+if (dataset !== undefined) {
+  var dataset$1 = Caml_option.valFromOption(dataset);
+  Webapi__Dom__DomStringMap.set("fooKey", "barValue", dataset$1);
+  Webapi__Dom__DomStringMap.get("fooKey", dataset$1);
+  Curry._2(Webapi__Dom__DomStringMap.unsafeDeleteKey, "fooKey", dataset$1);
+}
 
 exports.dataset = dataset;
-/* dataset Not a pure module */
+/* __x Not a pure module */

--- a/lib/js/tests/Webapi/Webapi__Dom/Webapi__Dom__GlobalEventHandlers__test.js
+++ b/lib/js/tests/Webapi/Webapi__Dom/Webapi__Dom__GlobalEventHandlers__test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var Curry = require("bs-platform/lib/js/curry.js");
 var TestHelpers = require("../../testHelpers.js");
 var Webapi__Dom__Document = require("../../../src/Webapi/Webapi__Dom/Webapi__Dom__Document.js");
 var Webapi__Dom__HtmlElement = require("../../../src/Webapi/Webapi__Dom/Webapi__Dom__HtmlElement.js");
@@ -28,7 +29,7 @@ elm.removeEventListener("selectionchange", handleSelection, {
 
 elm.removeEventListener("selectionchange", handleSelection, true);
 
-var htmlElm = TestHelpers.unsafelyUnwrapOption(Webapi__Dom__HtmlElement.ofElement(document.createElement("strong")));
+var htmlElm = TestHelpers.unsafelyUnwrapOption(Curry._1(Webapi__Dom__HtmlElement.ofElement, document.createElement("strong")));
 
 htmlElm.addEventListener("selectionchange", handleSelection, {
       passive: true,
@@ -47,7 +48,7 @@ htmlElm.removeEventListener("selectionchange", handleSelection, {
 
 htmlElm.removeEventListener("selectionchange", handleSelection, true);
 
-var htmlDoc = TestHelpers.unsafelyUnwrapOption(Webapi__Dom__Document.asHtmlDocument(document));
+var htmlDoc = TestHelpers.unsafelyUnwrapOption(Curry._1(Webapi__Dom__Document.asHtmlDocument, document));
 
 htmlDoc.addEventListener("selectionchange", handleSelection, {
       passive: true,

--- a/lib/js/tests/Webapi/Webapi__Dom/Webapi__Dom__HtmlDocument__test.js
+++ b/lib/js/tests/Webapi/Webapi__Dom/Webapi__Dom__HtmlDocument__test.js
@@ -1,12 +1,13 @@
 'use strict';
 
+var Curry = require("bs-platform/lib/js/curry.js");
 var TestHelpers = require("../../testHelpers.js");
 var Webapi__Dom__Document = require("../../../src/Webapi/Webapi__Dom/Webapi__Dom__Document.js");
 var Webapi__Dom__HtmlDocument = require("../../../src/Webapi/Webapi__Dom/Webapi__Dom__HtmlDocument.js");
 
 var el = document.createElement("strong");
 
-var htmlDocument = TestHelpers.unsafelyUnwrapOption(Webapi__Dom__Document.asHtmlDocument(document));
+var htmlDocument = TestHelpers.unsafelyUnwrapOption(Curry._1(Webapi__Dom__Document.asHtmlDocument, document));
 
 htmlDocument.activeElement;
 

--- a/lib/js/tests/Webapi/Webapi__Dom/Webapi__Dom__HtmlElement__test.js
+++ b/lib/js/tests/Webapi/Webapi__Dom/Webapi__Dom__HtmlElement__test.js
@@ -1,12 +1,13 @@
 'use strict';
 
+var Curry = require("bs-platform/lib/js/curry.js");
 var TestHelpers = require("../../testHelpers.js");
 var Webapi__Dom__Element = require("../../../src/Webapi/Webapi__Dom/Webapi__Dom__Element.js");
 var Webapi__Dom__HtmlElement = require("../../../src/Webapi/Webapi__Dom/Webapi__Dom__HtmlElement.js");
 
-var el = TestHelpers.unsafelyUnwrapOption(Webapi__Dom__Element.asHtmlElement(document.createElement("strong")));
+var el = TestHelpers.unsafelyUnwrapOption(Curry._1(Webapi__Dom__Element.asHtmlElement, document.createElement("strong")));
 
-var el2 = TestHelpers.unsafelyUnwrapOption(Webapi__Dom__Element.asHtmlElement(document.createElement("small")));
+var el2 = TestHelpers.unsafelyUnwrapOption(Curry._1(Webapi__Dom__Element.asHtmlElement, document.createElement("small")));
 
 var $$event = document.createEvent("my-event");
 

--- a/lib/js/tests/Webapi/Webapi__Dom/Webapi__Dom__Selection__test.js
+++ b/lib/js/tests/Webapi/Webapi__Dom/Webapi__Dom__Selection__test.js
@@ -1,11 +1,12 @@
 'use strict';
 
+var Curry = require("bs-platform/lib/js/curry.js");
 var TestHelpers = require("../../testHelpers.js");
 var Webapi__Dom__Document = require("../../../src/Webapi/Webapi__Dom/Webapi__Dom__Document.js");
 
 var node = document.createElement("strong");
 
-var sel = TestHelpers.unsafelyUnwrapOption(Webapi__Dom__Document.asHtmlDocument(document)).getSelection();
+var sel = TestHelpers.unsafelyUnwrapOption(Curry._1(Webapi__Dom__Document.asHtmlDocument, document)).getSelection();
 
 var range = new Range();
 

--- a/src/Webapi/Webapi__Dom/Webapi__Dom__Document.re
+++ b/src/Webapi/Webapi__Dom/Webapi__Dom__Document.re
@@ -1,17 +1,13 @@
 module Impl = (T: {type t;}) => {
   external asDocument : T.t => Dom.document = "%identity";
 
-  let asHtmlDocument: T.t => Js.null(Dom.htmlDocument) = [%bs.raw
-    {|
-    function (document) {
-      return document.doctype.name === "html" ?  document : null;
+  let asHtmlDocument: T.t => option(Dom.htmlDocument) = [%raw {|
+    function(document) {
+      if (document instanceof HTMLDocument) return document;
     }
-  |}
-  ];
-  [@deprecated "Will fail if no doctype is defined, consider using unsafeAsHtmlDocument instead"]
-  let asHtmlDocument: T.t => option(Dom.htmlDocument) =
-    (self) => Js.Null.toOption(asHtmlDocument(self));
+  |}];
 
+  [@deprecated "Unsafe cast, use [ashtmlDocument] instead"]
   external unsafeAsHtmlDocument : T.t => Dom.htmlDocument = "%identity";
 
   let ofNode = (node: Dom.node) : option(T.t) =>

--- a/src/Webapi/Webapi__Dom/Webapi__Dom__Element.re
+++ b/src/Webapi/Webapi__Dom/Webapi__Dom__Element.re
@@ -5,18 +5,13 @@ let ofNode = (node: Dom.node) : option('a) =>
     None;
 
 module Impl = (T: {type t;}) => {
-  let asHtmlElement: T.t => Js.null(Dom.htmlElement) = [%bs.raw
-    {|
-    function (element) {
-      // BEWARE: Assumes "contentEditable" uniquely identifies an HTMLELement
-      return element.contentEditable !== undefined ?  element : null;
+  let asHtmlElement: T.t => option(Dom.htmlElement) = [%raw {|
+    function(element) {
+      if (element instanceof HTMLElement) return element;
     }
-  |}
-  ];
-  [@deprecated "asHtmlElement uses a weak heuristic, consider using unsafeAsHtmlElement instead"]
-  let asHtmlElement: T.t => option(Dom.htmlElement) =
-    (self) => Js.Null.toOption(asHtmlElement(self));
+  |}];
 
+  [@deprecated "Unsafe cast, use [asHtmlElement] instead"]
   external unsafeAsHtmlElement : T.t => Dom.htmlElement = "%identity";
   let ofNode: Dom.node => option(T.t) = ofNode;
 

--- a/src/Webapi/Webapi__Dom/Webapi__Dom__HtmlElement.re
+++ b/src/Webapi/Webapi__Dom/Webapi__Dom__HtmlElement.re
@@ -1,16 +1,7 @@
 module Impl = (T: {type t;}) => {
   type t_htmlElement = T.t;
 
-  let ofElement: Dom.element => Js.null(t_htmlElement) = [%bs.raw
-    {|
-    function (element) {
-      // BEWARE: Assumes "contentEditable" uniquely identifies an HTMLELement
-      return element.contentEditable !== undefined ?  element : null;
-    }
-  |}
-  ];
-  [@deprecated "Consider using Element.asHtmlElement or Element.unsafeAsHtmlElement instead"]
-  let ofElement: Dom.element => option(t_htmlElement) = (self) => Js.Null.toOption(ofElement(self));
+  let ofElement = Webapi__Dom__Element.asHtmlElement;
 
   [@bs.get] external accessKey : t_htmlElement => string = "";
   [@bs.set] external setAccessKey : (t_htmlElement, string) => unit = "accessKey";

--- a/tests/Webapi/Webapi__Dom/Webapi__Dom__DomStringMap__test.re
+++ b/tests/Webapi/Webapi__Dom/Webapi__Dom__DomStringMap__test.re
@@ -4,9 +4,13 @@ open Webapi.Dom.DomStringMap;
 let dataset =
   document
   |> Document.createElement("div")
-  |> Element.unsafeAsHtmlElement
-  |> HtmlElement.dataset;
+  |> Element.asHtmlElement
+  |> Belt.Option.map(_, HtmlElement.dataset);
 
-let () = set("fooKey", "barValue", dataset);
-let _ = get("fooKey", dataset);
-let () = unsafeDeleteKey("fooKey", dataset);
+let () = switch (dataset) {
+  | Some(dataset) =>
+    set("fooKey", "barValue", dataset);
+    dataset |> get("fooKey") |> ignore;
+    unsafeDeleteKey("fooKey", dataset);
+  | None => ()
+};


### PR DESCRIPTION
This should be more robust than checking some properties of the objects themselves. Since the Web API classes like `HTMLDocument`, `HTMLElement` et al. are globally available in the browser we can just declare their constructors using `[@bs.val]` without having to worry about importing them.