### PR TITLE
Fix DomStringMap.unsafeDeleteKey to compile with BuckleScript 8

### DIFF
--- a/lib/js/src/Webapi/Webapi__Dom.js
+++ b/lib/js/src/Webapi/Webapi__Dom.js
@@ -24,6 +24,7 @@ var Webapi__Dom__CustomEvent = require("./Webapi__Dom/Webapi__Dom__CustomEvent.j
 var Webapi__Dom__HtmlElement = require("./Webapi__Dom/Webapi__Dom__HtmlElement.js");
 var Webapi__Dom__CdataSection = require("./Webapi__Dom/Webapi__Dom__CdataSection.js");
 var Webapi__Dom__DocumentType = require("./Webapi__Dom/Webapi__Dom__DocumentType.js");
+var Webapi__Dom__DomStringMap = require("./Webapi__Dom/Webapi__Dom__DomStringMap.js");
 var Webapi__Dom__HtmlDocument = require("./Webapi__Dom/Webapi__Dom__HtmlDocument.js");
 var Webapi__Dom__PointerEvent = require("./Webapi__Dom/Webapi__Dom__PointerEvent.js");
 var Webapi__Dom__RelatedEvent = require("./Webapi__Dom/Webapi__Dom__RelatedEvent.js");

--- a/lib/js/src/Webapi/Webapi__Dom/Webapi__Dom__DomStringMap.js
+++ b/lib/js/src/Webapi/Webapi__Dom/Webapi__Dom__DomStringMap.js
@@ -8,7 +8,7 @@ function get(key, map) {
 
 function set(key, value, map) {
   map[key] = value;
-  
+  return /* () */0;
 }
 
 var unsafeDeleteKey = (function(key, map) { delete map[key] });
@@ -16,4 +16,4 @@ var unsafeDeleteKey = (function(key, map) { delete map[key] });
 exports.get = get;
 exports.set = set;
 exports.unsafeDeleteKey = unsafeDeleteKey;
-/* No side effect */
+/* unsafeDeleteKey Not a pure module */

--- a/lib/js/src/Webapi/Webapi__Dom/Webapi__Dom__DomStringMap.js
+++ b/lib/js/src/Webapi/Webapi__Dom/Webapi__Dom__DomStringMap.js
@@ -8,10 +8,10 @@ function get(key, map) {
 
 function set(key, value, map) {
   map[key] = value;
-  return /* () */0;
+  
 }
 
-function unsafeDeleteKey (key,map){delete map[key];};
+var unsafeDeleteKey = (function(key, map) { delete map[key] });
 
 exports.get = get;
 exports.set = set;

--- a/lib/js/tests/Webapi/Webapi__Dom/Webapi__Dom__DomStringMap__test.js
+++ b/lib/js/tests/Webapi/Webapi__Dom/Webapi__Dom__DomStringMap__test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var Curry = require("bs-platform/lib/js/curry.js");
 var Webapi = require("../../../src/Webapi.js");
 var Webapi__Dom = require("../../../src/Webapi/Webapi__Dom.js");
 var Webapi__Dom__DomStringMap = require("../../../src/Webapi/Webapi__Dom/Webapi__Dom__DomStringMap.js");
@@ -10,7 +11,7 @@ Webapi__Dom__DomStringMap.set("fooKey", "barValue", dataset);
 
 Webapi__Dom__DomStringMap.get("fooKey", dataset);
 
-Webapi__Dom__DomStringMap.unsafeDeleteKey("fooKey", dataset);
+Curry._2(Webapi__Dom__DomStringMap.unsafeDeleteKey, "fooKey", dataset);
 
 exports.dataset = dataset;
 /* dataset Not a pure module */

--- a/src/Webapi/Webapi__Dom/Webapi__Dom__DomStringMap.re
+++ b/src/Webapi/Webapi__Dom/Webapi__Dom__DomStringMap.re
@@ -3,10 +3,10 @@ type t = Dom.domStringMap;
 type key = string;
 
 [@bs.get_index] [@bs.return nullable]
-external get: (t, key) => option(string) = "";
+external get: (t, key) => option(string);
 let get = (key, map) => get(map, key);
-[@bs.set_index] external set: (t, key, string) => unit = "";
+[@bs.set_index] external set: (t, key, string) => unit;
 let set = (key, value, map) => set(map, key, value);
-let unsafeDeleteKey: (key, t) => unit =  
-  [%raw (key, map) => "delete map[key];"];
-  
+let unsafeDeleteKey: (key, t) => unit = [%raw
+  "function(key, map) { delete map[key] }"
+];

--- a/src/Webapi/Webapi__Dom/Webapi__Dom__DomStringMap.re
+++ b/src/Webapi/Webapi__Dom/Webapi__Dom__DomStringMap.re
@@ -3,9 +3,9 @@ type t = Dom.domStringMap;
 type key = string;
 
 [@bs.get_index] [@bs.return nullable]
-external get: (t, key) => option(string);
+external get: (t, key) => option(string) = "";
 let get = (key, map) => get(map, key);
-[@bs.set_index] external set: (t, key, string) => unit;
+[@bs.set_index] external set: (t, key, string) => unit = "";
 let set = (key, value, map) => set(map, key, value);
 let unsafeDeleteKey: (key, t) => unit = [%raw
   "function(key, map) { delete map[key] }"


### PR DESCRIPTION
BuckleScript 8 (currently `bs-platform@dev`) removes the `[%raw (key, map) => "delete map[key];"]` syntax. (See https://github.com/BuckleScript/bucklescript/issues/4415) This PR changes that line of code so it can compile when BS8 releases.