### PR TITLE
Add labeled argument to Url.makeWithBase.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 0.18.1
+### 0.19.0
 * Added `Webapi.Url.makeWith`
 * Deprecated `Webapi.Url.makeWithBase` in favor of `Webapi.Url.makeWith`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.18.1
+* Added `Webapi.Url.makeWith`
+* Deprecated `Webapi.Url.makeWithBase` in favor of `Webapi.Url.makeWith`
+
 ### 0.18.0
 
 * Upgraded to bs-platform@7.1.0 and added API doc generation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-webapi",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Reason + BuckleScript bindings to DOM",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-webapi",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Reason + BuckleScript bindings to DOM",
   "repository": {
     "type": "git",

--- a/src/Webapi/Webapi__Url.re
+++ b/src/Webapi/Webapi__Url.re
@@ -21,7 +21,7 @@ module URLSearchParams = {
 type t;
 
 [@bs.new] external make: string => t = "URL";
-[@bs.new] external makeWithBase: (string, string) => t = "URL";
+[@bs.new] external makeWithBase: (string, ~base: string) => t = "URL";
 [@bs.get] external hash: t => string = "";
 [@bs.set] external setHash: (t, string) => unit = "hash";
 [@bs.get] external host: t => string = "";

--- a/src/Webapi/Webapi__Url.re
+++ b/src/Webapi/Webapi__Url.re
@@ -23,7 +23,7 @@ type t;
 [@bs.new] external make: string => t = "URL";
 [@deprecated "Use [makeWith] instead."]
 [@bs.new] external makeWithBase: (string, string) => t = "URL";
-/** @since 0.18.1 */
+/** @since 0.19.0 */
 [@bs.new] external makeWith: (string, ~base: string) => t = "URL";
 [@bs.get] external hash: t => string = "";
 [@bs.set] external setHash: (t, string) => unit = "hash";

--- a/src/Webapi/Webapi__Url.re
+++ b/src/Webapi/Webapi__Url.re
@@ -21,7 +21,10 @@ module URLSearchParams = {
 type t;
 
 [@bs.new] external make: string => t = "URL";
-[@bs.new] external makeWithBase: (string, ~base: string) => t = "URL";
+[@deprecated "Use [makeWith] instead."]
+[@bs.new] external makeWithBase: (string, string) => t = "URL";
+/** @since 0.18.1 */
+[@bs.new] external makeWith: (string, ~base: string) => t = "URL";
 [@bs.get] external hash: t => string = "";
 [@bs.set] external setHash: (t, string) => unit = "hash";
 [@bs.get] external host: t => string = "";


### PR DESCRIPTION
This is a minor (but breaking) change that adds a `~base` label to the second argument of `Url.makeWithBase`. I think the current signature, `(string, string) => t`, is ambiguous as to which string is the “base."