### PR TITLE
Fixes incorrect array_like type for URLSearchParams.entries()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ### 0.18.1
 
-* Fixed the binding for `Webapi.Url.URLSearchParams.entries` to return
-  `(string, string)`
+* Fixed the binding for `Webapi.Url.URLSearchParams.entries` to return `(string, string)`
 * Added `Webapi.Dom.Node.replaceChild`
 
 ### 0.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-### 0.18.1
+### 0.19.0
 
 * Fixed the binding for `Webapi.Url.URLSearchParams.entries` to return `(string, string)`
+
+### 0.18.1
+
 * Added `Webapi.Dom.Node.replaceChild`
 
 ### 0.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 ### 0.19.0
 
 * Fixed the binding for `Webapi.Url.URLSearchParams.entries` to return `(string, string)`
-
-### 0.18.1
-
 * Added `Webapi.Dom.Node.replaceChild`
 
 ### 0.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### 0.18.1
 
+* Fixed the binding for `Webapi.Url.URLSearchParams.entries` to return
+  `(string, string)`
 * Added `Webapi.Dom.Node.replaceChild`
 
 ### 0.18.0

--- a/lib/js/tests/Webapi/Webapi__Url__test.js
+++ b/lib/js/tests/Webapi/Webapi__Url__test.js
@@ -8,5 +8,10 @@ params.forEach((function (prim, prim$1) {
         
       }));
 
+var entries = Array.from(params.entries());
+
+console.log(entries);
+
 exports.params = params;
+exports.entries = entries;
 /* params Not a pure module */

--- a/lib/js/tests/Webapi/Webapi__Url__test.js
+++ b/lib/js/tests/Webapi/Webapi__Url__test.js
@@ -8,10 +8,12 @@ params.forEach((function (prim, prim$1) {
         
       }));
 
-var entries = Array.from(params.entries());
+function test_entries(params) {
+  return Array.from(params.entries());
+}
 
-console.log(entries);
+console.log(Array.from(params.entries()));
 
 exports.params = params;
-exports.entries = entries;
+exports.test_entries = test_entries;
 /* params Not a pure module */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-webapi",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Reason + BuckleScript bindings to DOM",
   "repository": {
     "type": "git",

--- a/src/Webapi/Webapi__Url.re
+++ b/src/Webapi/Webapi__Url.re
@@ -6,7 +6,7 @@ module URLSearchParams = {
   [@bs.new] external makeWithArray: array((string, string)) => t = "URLSearchParams";
   [@bs.send.pipe : t] external append: (string, string) => unit = "";
   [@bs.send.pipe : t] external delete: string => unit = "";
-  [@bs.send.pipe : t] external entries: Js.Array.array_like(string) = "";
+  [@bs.send.pipe : t] external entries: Js.Array.array_like((string, string)) = "";
   [@bs.send.pipe : t] external forEach: ([@bs.uncurry] (string, string) => unit) => unit = "";
   [@bs.return nullable][@bs.send.pipe : t] external get: string => option(string) = "";
   [@bs.send.pipe : t] external getAll: string => array(string) = "";

--- a/tests/Webapi/Webapi__Url__test.re
+++ b/tests/Webapi/Webapi__Url__test.re
@@ -2,5 +2,5 @@ open Webapi.Url;
 
 let params = URLSearchParams.make("key1=value1&key2=value2");
 URLSearchParams.forEach(Js.log2, params);
-let entries: array((string, string)) = Js.Array.from(URLSearchParams.entries(params));
-Js.log(entries);
+let test_entries = params => params |> URLSearchParams.entries |> Js.Array.from;
+Js.log(test_entries(params));

--- a/tests/Webapi/Webapi__Url__test.re
+++ b/tests/Webapi/Webapi__Url__test.re
@@ -2,3 +2,5 @@ open Webapi.Url;
 
 let params = URLSearchParams.make("key1=value1&key2=value2");
 URLSearchParams.forEach(Js.log2, params);
+let entries: array((string, string)) = Js.Array.from(URLSearchParams.entries(params));
+Js.log(entries);


### PR DESCRIPTION
I believe I followed the contributing guide, let me know if you would like any other changes.

This PR is to change the return value of the `Webapi__Url.URLSearchParams.entries` binding from `array_like(string)` to `array_like((string, string))`

```sh
$ node lib/js/tests/Webapi/Webapi__Url__test.js
value1 key1
value2 key2
[ [ 'key1', 'value1' ], [ 'key2', 'value2' ] ]
```

Fixes #190 
