### PR TITLE
Implement binding for Node.replaceChild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.18.1
+
+* Added `Webapi.Dom.Node.replaceChild`
+
 ### 0.18.0
 
 * Upgraded to bs-platform@7.1.0 and added API doc generation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-webapi",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Reason + BuckleScript bindings to DOM",
   "repository": {
     "type": "git",

--- a/src/Webapi/Dom/Webapi__Dom__Node.re
+++ b/src/Webapi/Dom/Webapi__Dom__Node.re
@@ -48,7 +48,7 @@ module Impl = (T: {type t;}) => {
   [@bs.send.pipe : T.t] external lookupPrefix : string = "lookupPrefix";
   [@bs.send.pipe : T.t] external normalize : unit = "";
   [@bs.send.pipe : T.t] external removeChild : Dom.node_like('a) => Dom.node_like('a) = "";
-  /* replacChild */
+  [@bs.send.pipe : T.t] external replaceChild : (Dom.node_like('a), Dom.node_like('b)) => Dom.node_like('b) = "";
 };
 
 type t = Dom.node;

--- a/tests/Webapi/Dom/Webapi__Dom__Node__test.re
+++ b/tests/Webapi/Dom/Webapi__Dom__Node__test.re
@@ -43,3 +43,4 @@ let _ = lookupNamespaceURI("https://...", node);
 let _ = lookupDefaultNamespaceURI(node);
 let _ = normalize(node);
 let _ = removeChild(node2, node);
+let _ = replaceChild(node3, node2, node);


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Node/replaceChild

The `replaceChild` api doesn't seem to care if the two arguments are the same type, so I bound it as returning the same type as the old child.

Fix #179