### PR TITLE
Add bindings for HtmlTemplateElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.19.2
+
+* Added `Webapi.Dom.HtmlTemplateElement`
+
 ### 0.19.1
 
 * Removed dev dependency on `bsdoc` to allow smooth installs on non-Mac

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-webapi",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Reason + BuckleScript bindings to DOM",
   "repository": {
     "type": "git",

--- a/src/Webapi/Dom/Webapi__Dom__HtmlTemplateElement.re
+++ b/src/Webapi/Dom/Webapi__Dom__HtmlTemplateElement.re
@@ -1,0 +1,8 @@
+type t;
+
+[@bs.get] external content: Dom.element => Dom.documentFragment = "content"
+
+include Webapi__Dom__Node.Impl({ type nonrec t = t; });
+include Webapi__Dom__EventTarget.Impl({ type nonrec t = t; });
+include Webapi__Dom__Element.Impl({ type nonrec t = t; });
+include Webapi__Dom__HtmlElement.Impl({ type nonrec t = t; });

--- a/src/Webapi/Webapi__Dom.re
+++ b/src/Webapi/Webapi__Dom.re
@@ -29,6 +29,7 @@ module HtmlElement = Webapi__Dom__HtmlElement;
 module HtmlFormElement = Webapi__Dom__HtmlFormElement;
 module HtmlImageElement = Webapi__Dom__HtmlImageElement;
 module HtmlInputElement = Webapi__Dom__HtmlInputElement;
+module HtmlTemplateElement = Webapi__Dom__HtmlTemplateElement;
 module IdbVersionChangeEvent = Webapi__Dom__IdbVersionChangeEvent;
 module Image = Webapi__Dom__Image;
 module InputEvent = Webapi__Dom__InputEvent;


### PR DESCRIPTION
This PR adds bindings for the `<template>` element as Webapi.Dom.HtmlTemplateElement.

Fixes #198