### PR TITLE
Removed peerDependency on bsdoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.19.2
+
+* Removed peer dependency on `bsdoc`
+
 ### 0.19.1
 
 * Removed dev dependency on `bsdoc` to allow smooth installs on non-Mac

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-webapi",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Reason + BuckleScript bindings to DOM",
   "repository": {
     "type": "git",
@@ -17,6 +17,7 @@
     "build": "bsb -make-world",
     "start": "bsb -w",
     "clean": "bsb -clean-world",
+    "doc-install": "npm install --no-save bsdoc",
     "test": "bsb -make-world && bsdoc build api && bsdoc support-files"
   },
   "files": [
@@ -30,8 +31,5 @@
   },
   "dependencies": {
     "bs-fetch": "^0.6.2"
-  },
-  "peerDependencies": {
-    "bsdoc": "^6.0.4-alpha"
   }
 }


### PR DESCRIPTION
Added a script to install it on demand instead. Fixes #200.