### PR TITLE
Add customevent functor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.19.3
+
+* Add a functor `MakeEmittedCustomEvent` to emit a detail of `CustomEvent`
+
 ### 0.19.2
 
 * Removed peer dependency on `bsdoc`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-webapi",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Reason + BuckleScript bindings to DOM",
   "repository": {
     "type": "git",

--- a/src/Webapi/Dom/Webapi__Dom__CustomEvent.re
+++ b/src/Webapi/Dom/Webapi__Dom__CustomEvent.re
@@ -5,7 +5,7 @@ include Webapi__Dom__Event.Impl({ type nonrec t = t; });
 [@bs.new] external make : string => t = "CustomEvent";
 [@bs.new] external makeWithOptions : (string, Js.t({..})) => t = "CustomEvent";
 
-module MakeEmittedCustomEvent = (T: {type t;}) => {
+module MakeCustomEvent = (Detail: {type t;}) => {
   type t = Dom.customEvent;
 
   include Webapi__Dom__Event.Impl({
@@ -13,6 +13,6 @@ module MakeEmittedCustomEvent = (T: {type t;}) => {
   });
 
   [@bs.new] external make: string => t = "CustomEvent";
-  [@bs.new] external makeWithOptions: (string, T.t) => t = "CustomEvent";
-  [@bs.get] external detail: t => T.t = "detail";
+  [@bs.new] external makeWithOptions: (string, Detail.t) => t = "CustomEvent";
+  [@bs.get] external detail: t => Detail.t = "detail";
 };

--- a/src/Webapi/Dom/Webapi__Dom__CustomEvent.re
+++ b/src/Webapi/Dom/Webapi__Dom__CustomEvent.re
@@ -13,6 +13,6 @@ module MakeEmittedCustomEvent = (T: {type t;}) => {
   });
 
   [@bs.new] external make: string => t = "CustomEvent";
-  [@bs.new] external makeWithOptions: (string, t) => t = "CustomEvent";
+  [@bs.new] external makeWithOptions: (string, T.t) => t = "CustomEvent";
   [@bs.get] external detail: t => T.t = "detail";
 };

--- a/src/Webapi/Dom/Webapi__Dom__CustomEvent.re
+++ b/src/Webapi/Dom/Webapi__Dom__CustomEvent.re
@@ -4,3 +4,15 @@ include Webapi__Dom__Event.Impl({ type nonrec t = t; });
 
 [@bs.new] external make : string => t = "CustomEvent";
 [@bs.new] external makeWithOptions : (string, Js.t({..})) => t = "CustomEvent";
+
+module MakeEmittedCustomEvent = (T: {type t;}) => {
+  type t = Dom.customEvent;
+
+  include Webapi__Dom__Event.Impl({
+    type nonrec t = t;
+  });
+
+  [@bs.new] external make: string => t = "CustomEvent";
+  [@bs.new] external makeWithOptions: (string, t) => t = "CustomEvent";
+  [@bs.get] external detail: t => T.t = "detail";
+};

--- a/tests/Webapi/Dom/Webapi__Dom__CustomEvent__test.re
+++ b/tests/Webapi/Dom/Webapi__Dom__CustomEvent__test.re
@@ -30,7 +30,7 @@ let t: Detail.t = {
     component: "test-component"
 };
 
-module EventWithDetail = MakeEmittedCustomEvent(Detail);
+module EventWithDetail = MakeCustomEvent(Detail);
 let eventWithDetail = EventWithDetail.make("event-with-detail");
 let eventWithOptions = EventWithDetail.makeWithOptions("event-with-detail", t);
 eventWithOptions->Webapi.Dom.EventTarget.dispatchEvent;

--- a/tests/Webapi/Dom/Webapi__Dom__CustomEvent__test.re
+++ b/tests/Webapi/Dom/Webapi__Dom__CustomEvent__test.re
@@ -32,6 +32,8 @@ let t: Detail.t = {
 
 module EventWithDetail = MakeEmittedCustomEvent(Detail);
 let eventWithDetail = EventWithDetail.make("event-with-detail");
+let eventWithOptions = EventWithDetail.makeWithOptions("event-with-detail", t);
+eventWithOptions->Webapi.Dom.EventTarget.dispatchEvent;
 
 /* Event */
 let _ = bubbles(eventWithDetail);
@@ -49,4 +51,4 @@ preventDefault(eventWithDetail);
 stopImmediatePropagation(eventWithDetail);
 stopPropagation(eventWithDetail);
 
-let _ = eventWithDetail->EventWithDetail.detail.component; 
+let _ = eventWithDetail->EventWithDetail.detail.component;

--- a/tests/Webapi/Dom/Webapi__Dom__CustomEvent__test.re
+++ b/tests/Webapi/Dom/Webapi__Dom__CustomEvent__test.re
@@ -18,3 +18,35 @@ let _ = isTrusted(event);
 preventDefault(event);
 stopImmediatePropagation(event);
 stopPropagation(event);
+
+/* Event with type detail */
+module Detail = {
+    type t = {
+        component:string
+    }
+}
+
+let t: Detail.t = {
+    component: "test-component"
+};
+
+module EventWithDetail = MakeEmittedCustomEvent(Detail);
+let eventWithDetail = EventWithDetail.make("event-with-detail");
+
+/* Event */
+let _ = bubbles(eventWithDetail);
+let _ = cancelable(eventWithDetail);
+let _ = composed(eventWithDetail);
+let _ = currentTarget(eventWithDetail);
+let _ = defaultPrevented(eventWithDetail);
+let _ = eventPhase(eventWithDetail);
+let _ = target(eventWithDetail);
+let _ = timeStamp(eventWithDetail);
+let _ = type_(eventWithDetail);
+let _ = isTrusted(eventWithDetail);
+
+preventDefault(eventWithDetail);
+stopImmediatePropagation(eventWithDetail);
+stopPropagation(eventWithDetail);
+
+let _ = eventWithDetail->EventWithDetail.detail.component; 

--- a/tests/Webapi/Dom/Webapi__Dom__EventTarget__test.re
+++ b/tests/Webapi/Dom/Webapi__Dom__EventTarget__test.re
@@ -31,6 +31,6 @@ let t: Detail.t = {
   test: "test"
 };
 
-module EventWithDetail = CustomEvent.MakeEmittedCustomEvent(Detail);
+module EventWithDetail = CustomEvent.MakeCustomEvent(Detail);
 let typedCustomEvent = EventWithDetail.makeWithOptions("event-with-detail", t);
 typedCustomEvent->Webapi.Dom.EventTarget.dispatchEvent;

--- a/tests/Webapi/Dom/Webapi__Dom__EventTarget__test.re
+++ b/tests/Webapi/Dom/Webapi__Dom__EventTarget__test.re
@@ -18,3 +18,19 @@ let _ = dispatchEvent(event, target);
 /* https://github.com/reasonml-community/bs-webapi-incubator/issues/103 */
 let customEvent = CustomEvent.makeWithOptions("custom-event", {"detail": {"test": "test"}});
 dispatchEvent(customEvent, target);
+
+
+/* another way */
+module Detail = {
+  type t = {
+      test: string
+  }
+};
+
+let t: Detail.t = {
+  test: "test"
+};
+
+module EventWithDetail = CustomEvent.MakeEmittedCustomEvent(Detail);
+let typedCustomEvent = EventWithDetail.makeWithOptions("event-with-detail", t);
+typedCustomEvent->Webapi.Dom.EventTarget.dispatchEvent;


### PR DESCRIPTION
This PR adds a functor to create `CustomEvent` with typed `detail`

Fix #203 