### PR TITLE
Add DataTransfer bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,12 @@ lib/*
 !lib/js/tests
 lib/js/tests/testHelpers.js
 npm-debug.log
+
+# direnv
+.envrc
+
+# Nix
+shell.nix
+
+# npm
+package-lock.json

--- a/src/Webapi/Dom/Webapi__Dom__DataTransfer.re
+++ b/src/Webapi/Dom/Webapi__Dom__DataTransfer.re
@@ -1,0 +1,19 @@
+type t = Dom.dataTransfer;
+
+[@bs.new] external make: unit => t = "DataTransfer";
+
+[@bs.get] external dropEffect: t => string = "dropEffect";
+[@bs.set] external setDropEffect: (t, string) => unit = "dropEffect";
+[@bs.get] external effectAllowed: t => string = "effectAllowed";
+[@bs.set] external setEffectAllowed: (t, string) => unit = "effectAllowed";
+/** TODO: items returns DataTransferItemList: https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-items */
+[@bs.send]
+external setDragImage: (t, Webapi__Dom__HtmlImageElement.t, float, float) => unit =
+  "setDragImage";
+[@bs.get] external types: t => array(string) = "types";
+[@bs.send] external getData: (t, string) => string = "getData";
+[@bs.send] external setData: (t, string, string) => unit = "setData";
+[@bs.send] external clearData: t => unit = "clearData";
+[@bs.send] external clearData0: t => unit = "clearData";
+[@bs.send] external clearData1: (t, string) => unit = "clearData";
+/** TODO: files returns FileList: https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-files */;

--- a/src/Webapi/Webapi__Dom.re
+++ b/src/Webapi/Webapi__Dom.re
@@ -9,6 +9,7 @@ module ClipboardEvent = Webapi__Dom__ClipboardEvent;
 module CloseEvent = Webapi__Dom__CloseEvent;
 module CompositionEvent = Webapi__Dom__CompositionEvent;
 module CustomEvent = Webapi__Dom__CustomEvent;
+module DataTransfer = Webapi__Dom__DataTransfer;
 module Document = Webapi__Dom__Document;
 module DocumentFragment = Webapi__Dom__DocumentFragment;
 module DocumentType = Webapi__Dom__DocumentType;


### PR DESCRIPTION
This PR adds bindings for [the `DataTransfer` API](https://html.spec.whatwg.org/multipage/dnd.html#datatransfer), commonly used in drag-and-drop and clipboard events.